### PR TITLE
ci(github): use `macos-13` in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest-large, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         version: [latest, 0.11.1]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest-large, windows-latest]
         version: [latest, 0.11.1]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## What is the motivation for this pull request?

`macos-latest` runs on macOS 14 Arm64, which is not supported by `cc-test-reporter`

https://docs.codeclimate.com/docs/configuring-test-coverage#locations-of-pre-built-binaries

https://github.com/actions/runner-images

## What is the current behavior?

GitHub Actions failing for macos image because CC binary cannot be downloaded

## What is the new behavior?

Switched to `macos-13` so amd64 architecture is used

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation